### PR TITLE
Fixed an nvram quoting issue to enable python -c

### DIFF
--- a/zvsh.py
+++ b/zvsh.py
@@ -206,7 +206,9 @@ class ZvShell(object):
 
     def create_nvram(self, verbosity):
         nvram = '[args]\n'
-        nvram += 'args = %s\n' % ' '.join([a.replace(',', '\\x2c') for a in self.nvram_args['args']])
+        nvram += 'args = %s\n' % ' '.join(
+            ['"%s"' % a.replace(',', '\\x2c').replace('"', '\\"')
+             for a in self.nvram_args['args']])
         if len(self.config['env']) > 0:
             nvram += '[env]\n'
             for k, v in self.config['env'].iteritems():


### PR DESCRIPTION
Previously, `zvsh --zvm-image=... python -c "<code>" did not work. This
fix adds some better quotation handling to enable this functionality.
This affects the generation of the nvram file.

If I get some time in the next few days during the summit, I'll update this pull request to add some tests as well.
