### PR TITLE
zvsh: fix a "line too long" pep8 error

### DIFF
--- a/zvsh
+++ b/zvsh
@@ -40,8 +40,8 @@ else:
         trace_log = os.path.abspath('zvsh.trace.log')
         zvm_run.extend(['-T', trace_log])
     zvm_run.append(manifest_file)
-    runner = zvsh.ZvRunner(zvm_run, zvshell.stdout, zvshell.stderr, zvshell.tmpdir,
-                           getrc=zvsh_args.args.zvm_getrc)
+    runner = zvsh.ZvRunner(zvm_run, zvshell.stdout, zvshell.stderr,
+                           zvshell.tmpdir, getrc=zvsh_args.args.zvm_getrc)
     try:
         runner.run()
     finally:


### PR DESCRIPTION
zvsh: fix a "line too long" pep8 error

As a side note, this error was causing nightlies to fail: http://ci.oslab.cc/job/zerovm-cli-nightly/11/
