### PR TITLE
zvsh: don't nuke working dirs when saving rt files

### DIFF
--- a/zvshlib/zvsh.py
+++ b/zvshlib/zvsh.py
@@ -697,10 +697,10 @@ class ZvShell(object):
         self.config = config
         self.savedir = savedir
         if self.savedir:
+            # user specified a savedir
             self.tmpdir = self.savedir
-            if os.path.isdir(self.tmpdir):
-                shutil.rmtree(self.tmpdir)
-            os.makedirs(self.tmpdir)
+            if not os.path.exists(self.tmpdir):
+                os.makedirs(self.tmpdir)
         else:
             self.tmpdir = mkdtemp()
         self.node_id = self.config['manifest']['Node']
@@ -889,8 +889,10 @@ class ZvRunner:
         self.getrc = getrc
         self.report = ''
         self.rc = -255
-        os.mkfifo(self.stdout)
-        os.mkfifo(self.stderr)
+        # create std{out,err} unless they already exist:
+        for stdfile in (self.stdout, self.stderr):
+            if not os.path.exists(stdfile):
+                os.mkfifo(stdfile)
 
     def run(self):
         try:


### PR DESCRIPTION
If the user specifies a save dir for the runtime files (manifest,
nvram, etc.), don't nuke the entire directory! The original intention of
this was to ensure that the runtime files do not overwrite existing
files, but this is a destructive approach (and could result in the some
serious damage to the user's system). When I first encountered this bug,
I lost an entire git clone directory; luckily it was backed up a remote
repo, but I hope the risk here is clear.

So instead of nuking the directory, this change simply checks if the
runtime files we expect to create (nvram.1, manifest.1, etc.) exist. If
any exist, we halt. Otherwise, we continue writing to the target save
directory, whether it is empty or not.

The behavior when no save dir is specified does not change; we still
will create and cleanup a tempdir in this case.

This is a minimal fix for https://github.com/zerovm/zerovm-cli/issues/10.
