### PR TITLE
add better return code handling

### DIFF
--- a/zvshlib/zvsh.py
+++ b/zvshlib/zvsh.py
@@ -917,6 +917,8 @@ class ZvRunner:
             rc = self.rc
             if self.getrc:
                 rc = self.process.returncode
+            else:
+                rc |= self.process.returncode << 4
             sys.exit(rc)
 
     def stdin_reader(self):


### PR DESCRIPTION
when there is a signal in untrusted code, the return code from the session is invalid
in that case we need to somehow pass zerovm return code outside
the common way of passing several return codes in one byte is by doing bitwise `or` into actual byte
this is what was implemented as a default behaviour
