### PR TITLE
add support for `/dev/self`

### DIFF
--- a/zvshlib/zvsh.py
+++ b/zvshlib/zvsh.py
@@ -797,6 +797,11 @@ class ZvShell(object):
                                           % (os.path.abspath('zvsh.log'),
                                              '/dev/debug'))
 
+    def add_self(self):
+        self.manifest_channels.append(self.channel_random_ro_template
+                                      % (os.path.abspath(self.program),
+                                         '/dev/self'))
+
     def create_nvram(self, verbosity):
         nvram = '[args]\n'
         nvram += 'args = %s\n' % ' '.join(
@@ -851,6 +856,7 @@ class ZvShell(object):
         self.add_debug(args.zvm_debug)
         self.add_untrusted_args(args.command, args.cmd_args)
         self.add_image_args(args.zvm_image)
+        self.add_self()
         self.create_nvram(args.zvm_verbosity)
         manifest_file = self.create_manifest()
         return manifest_file


### PR DESCRIPTION
ZRT and other libraries can use the nexe image binary file for some of their features
for example, to know the addresses of functions or to load some functions dynamically
we map the binary to a special device `/dev/self`, can be considered a ZeroVM ABI
the patch adds support for `/dev/self` channel into zvsh-generated manifests
