### PR TITLE
Fix Python 3 compatibility

### DIFF
--- a/zvshlib/tests/functional/tests.py
+++ b/zvshlib/tests/functional/tests.py
@@ -5,11 +5,18 @@ import unittest
 import errno
 from shutil import rmtree
 import sys
-from StringIO import StringIO
 import pytest
 import zvshlib
 from zvshlib.zvsh import Shell, DEFAULT_LIMITS
 from os.path import join as join_path
+
+try:
+    # Python 2
+    from cStringIO import BytesIO as BytesIO
+except ImportError:
+    # Python 3
+    from io import BytesIO
+
 
 MULTIVAL = ['channel']
 ZVSH = 'zvsh'
@@ -128,7 +135,7 @@ class TestZvsh(unittest.TestCase):
         tarfd, tarname = mkstemp(dir=self.testdir)
         os.close(tarfd)
         tar = tarfile.open(name=tarname, mode='w')
-        for name, f in name_and_file.iteritems():
+        for name, f in name_and_file.items():
             info = tarfile.TarInfo(name)
             f.seek(0, 2)
             size = f.tell()
@@ -315,11 +322,11 @@ class TestZvsh(unittest.TestCase):
             shell.zvsh.orig_cleanup()
 
     def test_image(self):
-        img1 = self._create_tar({'file1': StringIO('a'),
-                                 'file2': StringIO('b')})
+        img1 = self._create_tar({'file1': BytesIO(b'a'),
+                                 'file2': BytesIO(b'b')})
         img1_dev = '/dev/1.%s' % os.path.basename(img1)
-        img2 = self._create_tar({'file1': StringIO('a'),
-                                 'file2': StringIO('b')})
+        img2 = self._create_tar({'file1': BytesIO(b'a'),
+                                 'file2': BytesIO(b'b')})
         img2_dev = '/dev/2.%s' % os.path.basename(img2)
         opts = '--zvm-image=%s --zvm-image=%s,/lib' % (img1, img2)
         self.argv = [ZVSH]
@@ -368,11 +375,11 @@ class TestZvsh(unittest.TestCase):
             shell.zvsh.orig_cleanup()
 
     def test_image_extract(self):
-        img1 = self._create_tar({'file1': StringIO('a'),
-                                 'file2': StringIO('b')})
+        img1 = self._create_tar({'file1': BytesIO(b'a'),
+                                 'file2': BytesIO(b'b')})
         img1_dev = '/dev/1.%s' % os.path.basename(img1)
-        img2 = self._create_tar({'file3': StringIO('a'),
-                                 'file4': StringIO('b')})
+        img2 = self._create_tar({'file3': BytesIO(b'a'),
+                                 'file4': BytesIO(b'b')})
         img2_dev = '/dev/2.%s' % os.path.basename(img2)
         opts = '--zvm-image=%s --zvm-image=%s,/lib' % (img1, img2)
         self.program = 'file2'
@@ -424,8 +431,8 @@ class TestZvsh(unittest.TestCase):
             shell.zvsh.orig_cleanup()
 
     def test_wo_image(self):
-        img1 = self._create_tar({'file1': StringIO('a'),
-                                 'file2': StringIO('b')})
+        img1 = self._create_tar({'file1': BytesIO(b'a'),
+                                 'file2': BytesIO(b'b')})
         img1_dev = '/dev/1.%s' % os.path.basename(img1)
         opts = '--zvm-image=%s,/,wo' % img1
         self.argv = [ZVSH]
@@ -463,8 +470,8 @@ class TestZvsh(unittest.TestCase):
             shell.zvsh.orig_cleanup()
 
     def test_ro_wo_image(self):
-        img1 = self._create_tar({'file1': StringIO('a'),
-                                 'file2': StringIO('b')})
+        img1 = self._create_tar({'file1': BytesIO(b'a'),
+                                 'file2': BytesIO(b'b')})
         img1_dev = '/dev/1.%s' % os.path.basename(img1)
         opts = '--zvm-image=%s,/,ro --zvm-image=%s,/,wo' % (img1, img1)
         self.argv = [ZVSH]

--- a/zvshlib/zvsh.py
+++ b/zvshlib/zvsh.py
@@ -792,7 +792,7 @@ class ZvShell(object):
                 tmpnexe_fn = os.path.join(self.tmpdir,
                                           'boot.%d' % self.node_id)
                 tmpnexe_fd = open(tmpnexe_fn, 'wb')
-                read_iter = iter(lambda: nexe.read(65535), '')
+                read_iter = iter(lambda: nexe.read(65535), b'')
                 for chunk in read_iter:
                     tmpnexe_fd.write(chunk)
                 tmpnexe_fd.close()
@@ -818,7 +818,7 @@ class ZvShell(object):
              for a in self.nvram_args['args']])
         if len(self.config['env']) > 0:
             nvram += '[env]\n'
-            for k, v in self.config['env'].iteritems():
+            for k, v in self.config['env'].items():
                 nvram += 'name=%s,value=%s\n' % (k, v.replace(',', '\\x2c'))
         if len(self.nvram_fstab) > 0:
             nvram += '[fstab]\n'
@@ -944,7 +944,7 @@ class ZvRunner:
                 pass
         else:
             try:
-                for l in iter(lambda: sys.stdin.read(65535), ''):
+                for l in iter(lambda: sys.stdin.read(65535), b''):
                     self.process.stdin.write(l)
             except IOError:
                 pass
@@ -953,7 +953,7 @@ class ZvRunner:
     def stderr_reader(self):
         err = open(self.stderr)
         try:
-            for l in iter(lambda: err.read(65535), ''):
+            for l in iter(lambda: err.read(65535), b''):
                 sys.stderr.write(l)
         except IOError:
             pass
@@ -965,12 +965,12 @@ class ZvRunner:
             for line in pipe:
                 sys.stdout.write(line)
         else:
-            for line in iter(lambda: pipe.read(65535), ''):
+            for line in iter(lambda: pipe.read(65535), b''):
                 sys.stdout.write(line)
         pipe.close()
 
     def report_reader(self):
-        for line in iter(lambda: self.process.stdout.read(65535), ''):
+        for line in iter(lambda: self.process.stdout.read(65535), b''):
             self.report += line
 
     def spawn(self, daemon, func, **kwargs):


### PR DESCRIPTION
This includes fixes related to the use of strings/bytes as well
dict.iteritems().

NOTE: Code like `iter(lambda: sys.stdin.read(65535), ''):` was causing some tests to deadlock when running with py3. Not all of the instances of this pattern are covered by tests, but I updated them anyway. Please let me know if you find any problems with them.
