### PR TITLE
Add {posargs} for tox test run config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py26, py27, py32, py33, py34, pep8, pyflakes, full, doc
 [testenv]
 deps = -r{toxinidir}/test-requirements.txt
 commands = py.test \
+    {posargs} \
     --doctest-modules \
     --cov-report term-missing \
     --cov zvshlib \


### PR DESCRIPTION
This is useful because you can inject additional pytest flags and arguments (for running in verbose mode, running specific tests, etc.).

So now, any of the pytest invocation options (http://pytest.org/latest/usage.html) can be passed to tox, like so:

```
tox -e py27 -- -x -k test_foo
```
