### PR TITLE
setup: use setuptools over distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,15 +16,23 @@
 ZeroVM Shell
 """
 
-from distutils.core import setup
-
 import sys
-
-import zvshlib
 
 requires = []
 if sys.version_info < (2, 7):
     requires.append('ordereddict')
+
+kwargs = {}
+try:
+    from setuptools import setup
+    kwargs['install_requires'] = requires
+except ImportError:
+    sys.stderr.write('warning: setuptools not found, you must '
+                     'manually install dependencies!\n')
+    from distutils.core import setup
+
+import zvshlib
+
 
 VERSION = zvshlib.__version__
 
@@ -39,7 +47,6 @@ setup(
     platforms=['any'],
     packages=['zvshlib'],
     provides=['zvsh (%s)' % VERSION],
-    install_requires=requires,
     license='Apache 2.0',
     keywords='zvsh zerovm zvm',
     classifiers=(
@@ -53,4 +60,5 @@ setup(
         'Topic :: Software Development :: Build Tools',
     ),
     scripts=['zvsh'],
+    **kwargs
 )


### PR DESCRIPTION
Distutils is the stdlib packaging tool. However, setuptools is the
preferred tool for projects that define dependencies:

  https://python-packaging-user-guide.readthedocs.org/en/latest/current.html

Setuptools is a dependency of virtualenv and pip, so most developers
will have it installed.

Using setuptools means that the dependencies will be automatically
installed when running 'python setup.py install'. This is important
for the Read The Docs build since it installs the project like that
instead of using pip.

If setuptools is not present, a warning is printed and the
installation/packaging can continue.
