### PR TITLE
debian: remove explicit `zvsh` script install

### DIFF
--- a/debian/zerovm-cli.install
+++ b/debian/zerovm-cli.install
@@ -1,2 +1,1 @@
-zvsh /usr/bin
 zvsh.cfg /etc


### PR DESCRIPTION
In commit 2789559af309e63736cf35e74c72c22bf6618dd4, all scripts (`zvsh`,
`zpm`, `zvsh`) were moved into a `scripts/` directory in the root of the
repo. This broke packaging, because the `debian/zerovm-cli.install` file
was expecting the `zvsh` script to still be in the root of the repo,
instead of in the `scripts/` directory.

In fact, this directive wasn't needed; the `setup.py` and `debian/rules`
take care of script placement anyway.

This should fix last night's [Launchpad build failure](https://launchpad.net/~zerovm-ci/+archive/ubuntu/zerovm-latest/+build/6732770).