### PR TITLE
explicitly set up mappings on standard channels

### DIFF
--- a/zvshlib/tests/functional/tests.py
+++ b/zvshlib/tests/functional/tests.py
@@ -573,14 +573,29 @@ def _reference_nvram(command_line, additional_channels=None, images=None):
             'mode': 'char',
             'channel': '/dev/stdin'
         })
+    else:
+        reference['mapping'].append({
+            'mode': 'file',
+            'channel': '/dev/stdin'
+        })
     if sys.stdout.isatty():
         reference['mapping'].append({
             'mode': 'char',
             'channel': '/dev/stdout'
         })
+    else:
+        reference['mapping'].append({
+            'mode': 'file',
+            'channel': '/dev/stdout'
+        })
     if sys.stderr.isatty():
         reference['mapping'].append({
             'mode': 'char',
+            'channel': '/dev/stderr'
+        })
+    else:
+        reference['mapping'].append({
+            'mode': 'file',
             'channel': '/dev/stderr'
         })
     if additional_channels:

--- a/zvshlib/zvsh.py
+++ b/zvshlib/zvsh.py
@@ -80,6 +80,8 @@ args = %(args)s
 [mapping]
 %(mapping)s"""
 
+CHANNEL_MAPPING_TEMPLATE = "channel=/dev/%s,mode=%s\n"
+
 MANIFEST_TEMPLATE = """\
 Node = %(node)s
 Version = %(version)s
@@ -825,13 +827,12 @@ class ZvShell(object):
                 nvram += ('channel=%s,mountpoint=%s,access=%s,removable=no\n'
                           % (channel, mp, access))
         mapping = ''
-        if sys.stdin.isatty() or sys.stdout.isatty() or sys.stderr.isatty():
-            if sys.stdin.isatty():
-                mapping += 'channel=/dev/stdin,mode=char\n'
-            if sys.stdout.isatty():
-                mapping += 'channel=/dev/stdout,mode=char\n'
-            if sys.stderr.isatty():
-                mapping += 'channel=/dev/stderr,mode=char\n'
+        for std_name in ('stdin', 'stdout', 'stderr'):
+            std_chan = getattr(sys, std_name)
+            if std_chan.isatty():
+                mapping += CHANNEL_MAPPING_TEMPLATE % (std_name, 'char')
+            else:
+                mapping += CHANNEL_MAPPING_TEMPLATE % (std_name, 'file')
         for dev in self.nvram_reg_files:
             mapping += 'channel=%s,mode=file\n' % dev
         if mapping:


### PR DESCRIPTION
explicitly set up mapping to `file` or `char` on standard devices
set up `char` only in case of device connected to tty